### PR TITLE
Adjust logo and question spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
       <div className="min-h-screen relative">
         {showHeader && <Header />}
         
-        <main className={showHeader ? "px-4 py-2 max-w-sm mx-auto sm:max-w-lg md:max-w-2xl lg:max-w-4xl sm:px-6 relative z-10" : "relative z-10"}>
+        <main className={showHeader ? "px-4 py-0 max-w-sm mx-auto sm:max-w-lg md:max-w-2xl lg:max-w-4xl sm:px-6 relative z-10" : "relative z-10"}>
           <ErrorBoundary>
             <Routes>
               <Route path="/" element={<Home/>} />

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -1617,7 +1617,7 @@ export default function Quiz() {
       `}</style>
       
       <div 
-        className={`relative z-20 space-y-2 px-4 pt-2 pb-4 transition-all duration-500 ${
+        className={`relative z-20 space-y-2 px-4 pt-0 pb-4 transition-all duration-500 ${
           isPageLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
         }`}
       >

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 export default function Header() {
   return (
-    <header className="px-4 py-2 relative z-20">
+    <header className="px-4 py-1 relative z-20">
       <div className="flex items-center justify-between">
         <Link 
           to="/" 
@@ -12,7 +12,7 @@ export default function Header() {
           <img 
             src="/skiniq-logo.png" 
             alt="SkinIQ" 
-            className="h-32 w-auto group-hover:scale-105 transition-transform duration-300 drop-shadow-sm"
+            className="h-20 w-auto group-hover:scale-105 transition-transform duration-300 drop-shadow-sm"
           />
         </Link>
       </div>


### PR DESCRIPTION
Reduce vertical spacing between the header logo and the quiz content to create a more compact layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d454572-7b75-4410-9f51-a9ca66f4c8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d454572-7b75-4410-9f51-a9ca66f4c8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

