### PR TITLE
Log missing user profile

### DIFF
--- a/app/(miniapp)/quiz/page.tsx
+++ b/app/(miniapp)/quiz/page.tsx
@@ -56,6 +56,22 @@ export default function QuizPage() {
   const [hasResumed, setHasResumed] = useState(false); // Флаг: пользователь нажал "Продолжить" и восстановил прогресс
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+
+    if (showResumeScreen) {
+      url.searchParams.set('resume', 'true');
+    } else {
+      url.searchParams.delete('resume');
+    }
+
+    window.history.replaceState({}, '', url.toString());
+  }, [showResumeScreen]);
+
+  useEffect(() => {
     // Ждем готовности Telegram WebApp
     const waitForTelegram = (): Promise<void> => {
       return new Promise((resolve) => {
@@ -1019,19 +1035,6 @@ export default function QuizPage() {
     const answeredCount = Object.keys(savedProgress.answers).length;
     const totalQuestions = allQuestions.length;
     const progressPercent = totalQuestions > 0 ? Math.round((answeredCount / totalQuestions) * 100) : 0;
-
-    // Устанавливаем query параметр для скрытия навигации в layout
-    useEffect(() => {
-      if (showResumeScreen && typeof window !== 'undefined') {
-        const url = new URL(window.location.href);
-        url.searchParams.set('resume', 'true');
-        window.history.replaceState({}, '', url.toString());
-      } else if (typeof window !== 'undefined') {
-        const url = new URL(window.location.href);
-        url.searchParams.delete('resume');
-        window.history.replaceState({}, '', url.toString());
-      }
-    }, [showResumeScreen]);
 
     return (
       <div style={{ 


### PR DESCRIPTION
Move the `resume` query parameter `useEffect` hook to an unconditional block to fix "Rendered fewer hooks than expected" error when resuming the quiz.

The error occurred because the `useEffect` hook responsible for setting the `resume` query parameter was conditionally rendered within the resume overlay block. When the overlay was dismissed (`showResumeScreen` became `false`), React's rules for consistent hook ordering were violated, leading to a crash. Making the hook unconditional ensures stable rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b84679a-c07f-432c-a82f-4dae263a784b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b84679a-c07f-432c-a82f-4dae263a784b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

