### PR TITLE
Сайт на мобильном

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -391,6 +391,21 @@ body {
   box-sizing: border-box;
 }
 
+html, body {
+  overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+}
+
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}
+
 /* ИСПРАВЛЕНО (P2): Глобальные стили для админ-лейаута (вынесены из layout.tsx) */
 @keyframes gradientShift {
   0%, 100% { background-position: 0% 50%; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 // app/layout.tsx
 // Root layout для Next.js приложения
 
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import Script from 'next/script';
 import { Analytics } from '@vercel/analytics/react';
@@ -49,6 +49,14 @@ const inter = localFont({
   fallback: ['-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
   adjustFontFallback: false,
 });
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+};
 
 export const metadata: Metadata = {
   title: 'SkinIQ - Умный уход за кожей',
@@ -215,6 +223,8 @@ export default async function RootLayout({
   function showFallback(){
     var e = document.getElementById("loading-timeout-fallback");
     if (e && e.style.display !== "block") { e.style.cssText = fallbackCss; e.innerHTML = fallbackHtml; }
+    var rl = document.getElementById("root-loading");
+    if (rl && rl.parentNode) rl.parentNode.removeChild(rl);
   }
   function tryReloadOnce(){
     try {
@@ -235,7 +245,10 @@ export default async function RootLayout({
       else showFallback();
     }
   }, true);
-  // Не показываем плашку по таймеру — только при реальной ошибке загрузки чанка/скрипта
+  setTimeout(function(){
+    var rl = document.getElementById("root-loading");
+    if (rl && rl.parentNode) { rl.parentNode.removeChild(rl); showFallback(); }
+  }, 15000);
 })();
             `.trim(),
           }}


### PR DESCRIPTION
Add viewport meta tag, loading overlay timeout, and mobile CSS fixes to make the site usable on mobile devices.

The site was completely unusable on mobile due to the missing viewport meta tag, causing browsers to render it at desktop width. This PR also adds a timeout for the loading overlay to prevent infinite loading on slow connections and includes CSS fixes for safe-area insets and general mobile responsiveness.

---
<p><a href="https://cursor.com/agents/bc-18c3743d-0c00-4155-bcf7-91d91373350e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c3743d-0c00-4155-bcf7-91d91373350e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes global viewport behavior and global CSS (`html, body` overflow and safe-area padding), which can affect layout and accessibility across all pages, plus it alters the initial loading/fallback UX via an inline script timeout.
> 
> **Overview**
> Improves mobile usability by adding a Next.js `viewport` export (device-width, fixed scale, `viewportFit: 'cover'`) so browsers render at the correct mobile width.
> 
> Adds global mobile CSS to prevent horizontal overflow, disable tap highlight, and apply iOS safe-area insets via `env(safe-area-inset-*)` padding.
> 
> Updates the loading/fallback inline script to ensure the `#root-loading` overlay is removed on errors and now also after a 15s timeout, showing the reload fallback instead of potentially leaving users stuck on an infinite loader.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee86d96c30e57f4f0e79980f67bf59850d2f89d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->