### PR TITLE
fix(db): revert Prisma edge import (incompatible with adapter)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,7 +2,7 @@
 // Prisma Client для работы с базой данных (Neon PostgreSQL)
 // Использует @prisma/adapter-neon для совместимости с Cloudflare Workers/Pages
 
-import { PrismaClient } from '@prisma/client/edge';
+import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
 import { neonConfig } from '@neondatabase/serverless';
 


### PR DESCRIPTION
Using @prisma/client/edge with adapter throws an error. Must use @prisma/client with driverAdapters preview feature instead.