### PR TITLE
fix(db): run prisma generate before CF build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "check:product-coverage": "tsx scripts/check-product-coverage-by-skintype.ts",
     "add:combo-rules": "tsx scripts/add-combo-skin-rules.ts",
     "add:comprehensive-rules": "tsx scripts/add-comprehensive-rules.ts",
-    "build:cf": "npx @opennextjs/cloudflare build",
+    "build:cf": "prisma generate && npx @opennextjs/cloudflare build",
     "deploy:cf": "npx wrangler deploy",
     "preview:cf": "npx @opennextjs/cloudflare build && npx wrangler dev",
     "deploy:prod": "npx wrangler deploy --env production",


### PR DESCRIPTION
Ensures Prisma client is regenerated with driverAdapters before OpenNext bundles the app. Fixes fs.readdir error.