### PR TITLE
fix(db): Pool instance for PrismaNeon + remove $connect()

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,7 +4,7 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
-import { neonConfig } from '@neondatabase/serverless';
+import { Pool, neonConfig } from '@neondatabase/serverless';
 
 // В Cloudflare Workers используем встроенный WebSocket вместо ws-пакета
 // В Node.js среде (dev/scripts) neonConfig.webSocketConstructor не нужен
@@ -23,7 +23,9 @@ function createPrismaClient() {
     throw new Error('DATABASE_URL is not set');
   }
 
-  const adapter = new PrismaNeon({ connectionString: url });
+  // PrismaNeon требует Pool-инстанс из @neondatabase/serverless
+  const pool = new Pool({ connectionString: url });
+  const adapter = new PrismaNeon(pool);
 
   return new PrismaClient({
     adapter,
@@ -48,9 +50,11 @@ export const prisma = new Proxy({} as PrismaClient, {
 });
 
 // Функция для проверки подключения к БД
+// Не вызываем $connect() — с driver adapters соединение устанавливается лениво при первом запросе
 export async function checkDatabaseConnection() {
   try {
-    await prisma.$connect();
+    // Выполняем простой запрос вместо $connect(), чтобы не триггерить бинарный движок
+    await (getPrisma() as any).$queryRaw`SELECT 1`;
     return { connected: true };
   } catch (error: any) {
     console.error('❌ Database connection error:', error);


### PR DESCRIPTION
## Summary

- **Fix `PrismaNeon` initialization**: was passing a plain object `{ connectionString: url }` — should be a `Pool` instance from `@neondatabase/serverless`
- **Remove `prisma.$connect()`**: with driver adapters this call triggers native binary engine lookup, causing `[unenv] fs.readdir is not implemented yet!` on Cloudflare Workers. Replaced with `$queryRaw\`SELECT 1\`` for the health check.

## Root cause

`fs.readdir` error in CF Workers was caused by Prisma trying to find a native engine binary when `$connect()` was called. With `driverAdapters` preview feature, the binary engine should not be needed — but `$connect()` still triggers engine discovery.

## Test plan

- [ ] Merge into `develop`
- [ ] Wait for CF staging build to complete
- [ ] Check `https://staging.proskiniq.ru/api/health` — `database.status` should be `"ok"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)