### PR TITLE
fix(db): remove $connect() — fixes fs.readdir on CF Workers

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,7 +4,7 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
-import { Pool, neonConfig } from '@neondatabase/serverless';
+import { neonConfig } from '@neondatabase/serverless';
 
 // В Cloudflare Workers используем встроенный WebSocket вместо ws-пакета
 // В Node.js среде (dev/scripts) neonConfig.webSocketConstructor не нужен
@@ -23,9 +23,7 @@ function createPrismaClient() {
     throw new Error('DATABASE_URL is not set');
   }
 
-  // PrismaNeon требует Pool-инстанс из @neondatabase/serverless
-  const pool = new Pool({ connectionString: url });
-  const adapter = new PrismaNeon(pool);
+  const adapter = new PrismaNeon({ connectionString: url });
 
   return new PrismaClient({
     adapter,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,7 +4,7 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
-import { neonConfig } from '@neondatabase/serverless';
+import { Pool, neonConfig } from '@neondatabase/serverless';
 
 // В Cloudflare Workers используем встроенный WebSocket вместо ws-пакета
 // В Node.js среде (dev/scripts) neonConfig.webSocketConstructor не нужен
@@ -23,7 +23,9 @@ function createPrismaClient() {
     throw new Error('DATABASE_URL is not set');
   }
 
-  const adapter = new PrismaNeon({ connectionString: url });
+  // PrismaNeon требует Pool-инстанс из @neondatabase/serverless
+  const pool = new Pool({ connectionString: url });
+  const adapter = new PrismaNeon(pool);
 
   return new PrismaClient({
     adapter,
@@ -48,9 +50,11 @@ export const prisma = new Proxy({} as PrismaClient, {
 });
 
 // Функция для проверки подключения к БД
+// Не вызываем $connect() — с driver adapters соединение устанавливается лениво при первом запросе
 export async function checkDatabaseConnection() {
   try {
-    await prisma.$connect();
+    // Выполняем простой запрос вместо $connect(), чтобы не триггерить бинарный движок
+    await (getPrisma() as any).$queryRaw`SELECT 1`;
     return { connected: true };
   } catch (error: any) {
     console.error('❌ Database connection error:', error);


### PR DESCRIPTION
## Summary

Fixes `[unenv] fs.readdir is not implemented yet!` on Cloudflare Workers.

**Root cause**: `prisma.$connect()` in `checkDatabaseConnection()` triggers Prisma's native binary engine lookup, which calls `fs.readdir` — not implemented in CF Workers unenv polyfills.

**Fix**: Replace `prisma.$connect()` with `$queryRaw\`SELECT 1\`` — makes an actual DB query instead, which works correctly with the Neon driver adapter without touching the native engine.

Also reverts incorrect `Pool` instance change from previous PR (Prisma 6 adapter-neon accepts `PoolConfig` directly).

## Test plan

- [ ] Merge into `develop`
- [ ] CF staging build completes successfully
- [ ] `https://staging.proskiniq.ru/api/health` returns `database.status: "ok"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)