### PR TITLE
fix(db): PoolConfig for PrismaNeon, no Pool instance

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,7 +4,7 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaNeon } from '@prisma/adapter-neon';
-import { Pool, neonConfig } from '@neondatabase/serverless';
+import { neonConfig } from '@neondatabase/serverless';
 
 // В Cloudflare Workers используем встроенный WebSocket вместо ws-пакета
 // В Node.js среде (dev/scripts) neonConfig.webSocketConstructor не нужен
@@ -23,9 +23,8 @@ function createPrismaClient() {
     throw new Error('DATABASE_URL is not set');
   }
 
-  // PrismaNeon требует Pool-инстанс из @neondatabase/serverless
-  const pool = new Pool({ connectionString: url });
-  const adapter = new PrismaNeon(pool);
+  // @prisma/adapter-neon@6.x принимает PoolConfig напрямую (не Pool-инстанс)
+  const adapter = new PrismaNeon({ connectionString: url });
 
   return new PrismaClient({
     adapter,


### PR DESCRIPTION
## Summary

Fixes TypeScript build error on Cloudflare:

```
Type error: Type 'Pool' has no properties in common with type 'PoolConfig'
```

`@prisma/adapter-neon@6.x` accepts `PoolConfig` object directly — not a `Pool` instance. Removes the incorrect `Pool` import and usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)