### PR TITLE
fix(bundle): native .wasm import via webpack externals — fixes 14.9MB…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -109,7 +109,10 @@ const nextConfig = {
     // OpenNext esbuild перехватит эти require через плагин setWranglerExternal и пометит
     // как external с абсолютным путём — wrangler загрузит их отдельно (CompiledWasm).
     // Итог: .wasm НЕ попадает в JS бандл (3 МБ limit free tier соблюдается).
-    if (isServer && process.env.CF_PAGES === '1') {
+    // Применяем для ВСЕХ webpack компиляций (server + client) на CF Pages.
+    // Клиентская компиляция тоже обходит граф зависимостей для lazy чанков
+    // (напр. await import('@/lib/db') в logger.ts) и встречает .wasm файл.
+    if (process.env.CF_PAGES === '1') {
       const existingExternals = Array.isArray(config.externals)
         ? config.externals
         : config.externals

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 import withBundleAnalyzer from '@next/bundle-analyzer';
 import { createRequire } from 'module';
-import { existsSync } from 'fs';
-import path from 'path';
 
 const _require = createRequire(import.meta.url);
 
@@ -103,35 +101,6 @@ const nextConfig = {
       ...config.resolve.alias,
       '@prisma/client/wasm': _require.resolve('@prisma/client/wasm.js'),
     };
-
-    // На Cloudflare Pages (CF_PAGES=1): помечаем .wasm как внешние CommonJS зависимости.
-    // webpack не парсит WASM файлы, просто эмитит require('/abs/path/file.wasm').
-    // OpenNext esbuild перехватит эти require через плагин setWranglerExternal и пометит
-    // как external с абсолютным путём — wrangler загрузит их отдельно (CompiledWasm).
-    // Итог: .wasm НЕ попадает в JS бандл (3 МБ limit free tier соблюдается).
-    // Применяем для ВСЕХ webpack компиляций (server + client) на CF Pages.
-    // Клиентская компиляция тоже обходит граф зависимостей для lazy чанков
-    // (напр. await import('@/lib/db') в logger.ts) и встречает .wasm файл.
-    if (process.env.CF_PAGES === '1') {
-      const existingExternals = Array.isArray(config.externals)
-        ? config.externals
-        : config.externals
-        ? [config.externals]
-        : [];
-      config.externals = [
-        ...existingExternals,
-        async ({ context, request }) => {
-          if (request && request.endsWith('.wasm')) {
-            try {
-              const abs = path.resolve(context, request);
-              if (existsSync(abs)) return `commonjs ${abs}`;
-            } catch {
-              // ignore resolution errors
-            }
-          }
-        },
-      ];
-    }
 
     if (!isServer) {
       config.resolve.fallback = {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 import withBundleAnalyzer from '@next/bundle-analyzer';
 import { createRequire } from 'module';
+import { existsSync } from 'fs';
+import path from 'path';
 
 const _require = createRequire(import.meta.url);
 
@@ -96,22 +98,37 @@ const nextConfig = {
   // Исключаем src из сборки (Vite фронтенд)
   // ОПТИМИЗАЦИЯ: Code splitting для уменьшения размера бандла
   webpack: (config, { isServer }) => {
-    // @prisma/client/wasm.mjs не существует — форсируем CJS версию (wasm.js) через alias
-    // Алиасируем все non-postgresql WASM на postgresql чтобы webpack не бандлил 5×копий (14.5 МБ!)
-    // Prisma WASM: каждый провайдер = 2.9 МБ base64 JS. Нам нужен только postgresql.
-    const pgWasmPath = _require.resolve('@prisma/client/runtime/query_engine_bg.postgresql.wasm-base64.js');
-    const nonPgProviders = ['mysql', 'sqlite', 'sqlserver', 'cockroachdb'];
-    const wasmAliases = {};
-    for (const p of nonPgProviders) {
-      wasmAliases[`@prisma/client/runtime/query_engine_bg.${p}.wasm-base64`] = pgWasmPath;
-      wasmAliases[`@prisma/client/runtime/query_engine_bg.${p}.wasm-base64.js`] = pgWasmPath;
-      wasmAliases[`@prisma/client/runtime/query_engine_bg.${p}.wasm-base64.mjs`] = pgWasmPath;
-    }
+    // @prisma/client/wasm.mjs не существует — форсируем CJS версию (wasm.js)
     config.resolve.alias = {
       ...config.resolve.alias,
       '@prisma/client/wasm': _require.resolve('@prisma/client/wasm.js'),
-      ...wasmAliases,
     };
+
+    // На Cloudflare Pages (CF_PAGES=1): помечаем .wasm как внешние CommonJS зависимости.
+    // webpack не парсит WASM файлы, просто эмитит require('/abs/path/file.wasm').
+    // OpenNext esbuild перехватит эти require через плагин setWranglerExternal и пометит
+    // как external с абсолютным путём — wrangler загрузит их отдельно (CompiledWasm).
+    // Итог: .wasm НЕ попадает в JS бандл (3 МБ limit free tier соблюдается).
+    if (isServer && process.env.CF_PAGES === '1') {
+      const existingExternals = Array.isArray(config.externals)
+        ? config.externals
+        : config.externals
+        ? [config.externals]
+        : [];
+      config.externals = [
+        ...existingExternals,
+        async ({ context, request }) => {
+          if (request && request.endsWith('.wasm')) {
+            try {
+              const abs = path.resolve(context, request);
+              if (existsSync(abs)) return `commonjs ${abs}`;
+            } catch {
+              // ignore resolution errors
+            }
+          }
+        },
+      ];
+    }
 
     if (!isServer) {
       config.resolve.fallback = {

--- a/scripts/patch-prisma-wasm-loader.mjs
+++ b/scripts/patch-prisma-wasm-loader.mjs
@@ -1,18 +1,22 @@
 /**
- * Патч для Prisma WASM loader — base64 подход для Cloudflare Workers.
+ * Патч для Prisma WASM loader — нативный импорт для Cloudflare Workers.
  *
- * Проблема: wasm-worker-loader.mjs делает `import('./query_engine_bg.wasm')`
- * который не работает в CF Workers через @opennextjs/cloudflare, вызывая fallback
- * к fs.readdir (не реализован в unenv).
+ * Проблема с base64 подходом: webpack/esbuild включает ~3 МБ base64 строку в JS бандл,
+ * раздувая handler.mjs до 14+ МБ и превышая лимит CF Workers (3 МБ для free tier).
  *
- * Решение: заменить loader на версию которая импортирует WASM как base64 строку
- * из @prisma/client/runtime/query_engine_bg.postgresql.wasm-base64.mjs
- * и компилирует его через WebAssembly.compile() — работает нативно в CF Workers.
+ * Правильный подход: нативный `import wasm from './query_engine_bg.wasm'`.
  *
- * ВАЖНО: webpack алиасы в next.config.mjs направляют все non-postgresql WASM
- * на postgresql, предотвращая бандлинг 5× копий (14.5 МБ → 2.9 МБ).
+ * Поток:
+ *  1. webpack видит .wasm импорт → externals функция (next.config.mjs) возвращает
+ *     `commonjs /absolute/path/query_engine_bg.wasm` → webpack НЕ парсит WASM файл,
+ *     просто эмитит require('/abs/path/...wasm') в выходных чанках.
+ *  2. OpenNext esbuild обрабатывает чанки → плагин setWranglerExternal перехватывает
+ *     .wasm импорты, помечает как external с абсолютным путём.
+ *  3. wrangler deploy: видит import .wasm, применяет [[rules]] CompiledWasm,
+ *     загружает WASM как отдельный модуль (не считается в лимите JS 3 МБ).
+ *  4. В CF Workers: импорт резолвится в WebAssembly.Module — именно это ожидает Prisma.
  *
- * Запускать ПОСЛЕ prisma generate, ДО next build.
+ * Запускать ПОСЛЕ prisma generate, ДО next build (как часть build:cf).
  */
 
 import { writeFileSync, existsSync } from 'fs';
@@ -29,15 +33,14 @@ if (!existsSync(loaderPath)) {
   process.exit(1);
 }
 
-// Loader использует base64-encoded WASM вместо import('.wasm')
-// Формат возврата: Promise<{ default: WebAssembly.Module }> — как ожидает Prisma
+// Нативный импорт .wasm — wrangler загружает его как WebAssembly.Module отдельно от JS.
+// Prisma ожидает Promise<{ default: WebAssembly.Module }> из этого лоадера.
 const patchedContent = `/* patched by scripts/patch-prisma-wasm-loader.mjs for Cloudflare Workers */
-/* Original: export default import('./query_engine_bg.wasm') */
-/* Uses base64-encoded WASM to avoid fs.readdir in CF Workers unenv */
-import { wasm as wasmBase64 } from '@prisma/client/runtime/query_engine_bg.postgresql.wasm-base64.mjs';
-const bytes = Uint8Array.from(atob(wasmBase64), (c) => c.charCodeAt(0));
-export default WebAssembly.compile(bytes).then((mod) => ({ default: mod }));
+/* Native .wasm import — wrangler bundles it as a separate WebAssembly module */
+/* NOT counted in the 3 MB JS script size limit */
+import wasm from './query_engine_bg.wasm';
+export default Promise.resolve({ default: wasm });
 `;
 
 writeFileSync(loaderPath, patchedContent, 'utf8');
-console.log('✅ Patched Prisma WASM loader for Cloudflare Workers (base64 approach)');
+console.log('✅ Patched Prisma WASM loader: native .wasm import (CF Workers CompiledWasm)');

--- a/scripts/patch-prisma-wasm-loader.mjs
+++ b/scripts/patch-prisma-wasm-loader.mjs
@@ -33,14 +33,24 @@ if (!existsSync(loaderPath)) {
   process.exit(1);
 }
 
-// Нативный импорт .wasm — wrangler загружает его как WebAssembly.Module отдельно от JS.
-// Prisma ожидает Promise<{ default: WebAssembly.Module }> из этого лоадера.
+// Абсолютный путь к WASM бинарю — вычисляется здесь, во время патча, чтобы esbuild
+// мог резолвить его через setWranglerExternal (resolve(dirname(importer), absPath) = absPath).
+const wasmBinaryPath = resolve(projectRoot, 'node_modules/.prisma/client/query_engine_bg.wasm');
+
+if (!existsSync(wasmBinaryPath)) {
+  console.error('❌ query_engine_bg.wasm not found — run prisma generate first');
+  process.exit(1);
+}
+
+// /* webpackIgnore: true */ — webpack полностью пропускает этот импорт (не парсит .wasm как JS).
+// esbuild (OpenNext setWranglerExternal) перехватывает .wasm импорт, помечает как external.
+// wrangler загружает WASM отдельно как CompiledWasm (не входит в 3 МБ лимит JS).
+// Динамический импорт возвращает Promise<{ default: WebAssembly.Module }> — именно то, что ждёт Prisma.
 const patchedContent = `/* patched by scripts/patch-prisma-wasm-loader.mjs for Cloudflare Workers */
-/* Native .wasm import — wrangler bundles it as a separate WebAssembly module */
-/* NOT counted in the 3 MB JS script size limit */
-import wasm from './query_engine_bg.wasm';
-export default Promise.resolve({ default: wasm });
+/* webpackIgnore: webpack skips this import entirely — no "Module parse failed" */
+/* esbuild setWranglerExternal marks .wasm as external → wrangler CompiledWasm */
+export default import(/* webpackIgnore: true */ ${JSON.stringify(wasmBinaryPath)});
 `;
 
 writeFileSync(loaderPath, patchedContent, 'utf8');
-console.log('✅ Patched Prisma WASM loader: native .wasm import (CF Workers CompiledWasm)');
+console.log('✅ Patched Prisma WASM loader: webpackIgnore + absolute path (CF Workers CompiledWasm)');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,9 +13,11 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 
 # WASM modules — Prisma query engine (handled as native WebAssembly, not bundled into JS)
+# fallthrough = false: suppress warning about default CompiledWasm rule being shadowed
 [[rules]]
 type = "CompiledWasm"
 globs = ["**/*.wasm"]
+fallthrough = false
 
 # Cron только для prod — настраивается вручную в CF Dashboard для staging
 # [triggers]


### PR DESCRIPTION
… bundle

Base64 approach embedded 3MB WASM as a JS string, even after aliasing non-postgresql providers, the bundle was still ~3-4MB JS (exceeds free tier 3MB).

Root cause: OpenNext Cloudflare's esbuild plugin `setWranglerExternal` already handles native .wasm imports by marking them external (absolute path), letting wrangler upload WASM as a CompiledWasm module separate from the JS script. But webpack was processing the .wasm import before esbuild could intercept it.

Fix: on Cloudflare Pages builds (CF_PAGES=1), webpack externals function marks .wasm files as `commonjs /absolute/path/file.wasm`. webpack emits a require() call without parsing the binary — no "Module parse failed" error, no 3MB base64. OpenNext esbuild then intercepts the require via setWranglerExternal and keeps it external. wrangler uploads the 2.3MB binary as a separate WebAssembly module.

Expected bundle: handler.mjs ~1-2MB (JS only) vs previous 14.9MB. WASM module (2.3MB) is separate — not counted in the 3MB JS script limit.